### PR TITLE
Enable query transformations for deep replay

### DIFF
--- a/src/replay/deep.clj
+++ b/src/replay/deep.clj
@@ -11,14 +11,6 @@
   (:import (java.time Instant)))
 
 (def DEFAULT_DEPTH 1)
-(def DEFAULT_PAGE_SIZE 3000)
-
-(defn prepare-query [query replay-conf]
-  (-> query
-      (assoc :size (min (or (:depth replay-conf) DEFAULT_DEPTH) DEFAULT_PAGE_SIZE))
-      (assoc :_source true)
-      (assoc :explain true)
-      (assoc :sort ["_score" {:created_at "desc"}])))
 
 (defn additional-data [query-log-attrs query-log-entry-source]
   (loop [[attr & attrs] query-log-attrs
@@ -47,7 +39,7 @@
             transform-fn (transform-query/transform-fn (:query-transforms replay-conf))
             ^String raw-query (get-in query-log-entry-source query-selector)
             ^String transformed-query (transform-fn raw-query)
-            prepared-query (-> transformed-query json/decode (prepare-query replay-conf))
+            prepared-query (-> transformed-query json/decode)
             hits (es/fetch {:max_docs depth
                             :source   {:remote   {:host dest-es-host}
                                        :index    index-name

--- a/src/replay/transform/query.clj
+++ b/src/replay/transform/query.clj
@@ -13,7 +13,7 @@
 ;; TODO: optimize consecutive JQ scripts to be executed in one pass
 (defn transform-fn [transforms]
   (let [tf-fn (apply comp (map compile-transform (reverse transforms)))]
-    (fn [query] (tf-fn query))))
+    (fn [^String query] (tf-fn query))))
 
 (comment
   ;; Applies transforms on the input string in order


### PR DESCRIPTION
TL;DR: For cases when `rescore` is used in original query.

Deep replay adds several things to the original query that would make it easier to fetch many hits:
```
(defn prepare-query [query replay-conf]
  (-> query
      (assoc :size (min (or (:depth replay-conf) DEFAULT_DEPTH) DEFAULT_PAGE_SIZE))
      (assoc :_source true)
      (assoc :explain true)
      (assoc :sort ["_score" {:created_at "desc"}]))) 
```
Since `sort` and `rescore` are incompatible, we might want to change the query so that it would be possible to execute the deep replay.

One option is in `prepare-query` remove the `rescore` clause. It would work.  But if we would like to fetch hits with a modified query then we would need to expose the query transformation logic anyway. 

So, add a transformation:
```
{
  "lang": "js",
  "script": "function tx(q,v){delete q.rescore;q._source=true;q.explain=true;let original_sort=q.sort;let sort=['_score',{created_at:'desc'}];if(original_sort==null){sort.concat(original_sort)}q.sort=sort;return q}"
}
```